### PR TITLE
Ghost Ember upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A list of open source Ember apps
 
 ## Ember `2.5.x`
 * [Travis CI web client](https://github.com/travis-ci/travis-web)
+* [Ghost](https://github.com/TryGhost/Ghost/tree/master/core/client)
 
 ## Ember `2.4.x`
 * [Ember Observer](https://github.com/emberobserver/client)
@@ -14,7 +15,6 @@ A list of open source Ember apps
 ## Ember `2.2.x`
 
 * [HospitalRun](https://github.com/HospitalRun/hospitalrun-frontend)
-* [Ghost](https://github.com/TryGhost/Ghost/tree/master/core/client)
 * [Ember Twiddle](https://github.com/ember-cli/ember-twiddle)
 
 ## Ember `2.1.x`


### PR DESCRIPTION
Ghost master is now at 2.5 (as of a couple weeks ago).

Ghost stable is at 2.4 (as of version 0.7.9 of Ghost).
