### PR TITLE
Update Ghost repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A list of open source Ember apps
 
 ## Ember `2.5.x`
 * [Travis CI web client](https://github.com/travis-ci/travis-web)
-* [Ghost](https://github.com/TryGhost/Ghost/tree/master/core/client)
+* [Ghost](https://github.com/TryGhost/Ghost-Admin)
 
 ## Ember `2.4.x`
 * [Ember Grep web client](https://github.com/EmberGrep/eg-site)


### PR DESCRIPTION
Ghost's ember.js admin client has now been split out into it's own repository so the old link was returning a 404.
