### PR TITLE
Add Ember Guides App

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A list of open source Ember apps
 * [Radio4000](https://github.com/internet4000/radio4000)
 
 ## Ember `3.1.x`
+* [Ember Guides App](https://github.com/ember-learn/guides-app)
 * [Ember Inspector](https://github.com/emberjs/ember-inspector)
 * [Percy web client](https://github.com/percy/percy-web)
 * [Ship Shape](https://github.com/shipshapecode/shipshape.io)


### PR DESCRIPTION
The [Ember Guides App](https://guides.emberjs.com) is now an Ember app [running 3.1.x](https://github.com/ember-learn/guides-app/blob/6ad3b2749527c5664838a88932f1bca3018eae71/package.json#L61).